### PR TITLE
Update hash s11 for MRR

### DIFF
--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -9,7 +9,7 @@ import (
 	"github.com/HyperspaceApp/Hyperspace/encoding"
 	"github.com/HyperspaceApp/fastrand"
 
-	"github.com/HyperspaceApp/ed25519
+	"github.com/HyperspaceApp/ed25519"
 )
 
 const (

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -9,7 +9,7 @@ import (
 	"github.com/HyperspaceApp/Hyperspace/encoding"
 	"github.com/HyperspaceApp/fastrand"
 
-	"github.com/HyperspaceApp/ed25519"
+	"golang.org/x/crypto/ed25519"
 )
 
 const (

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -9,7 +9,7 @@ import (
 	"github.com/HyperspaceApp/Hyperspace/encoding"
 	"github.com/HyperspaceApp/fastrand"
 
-	"golang.org/x/crypto/ed25519"
+	"github.com/HyperspaceApp/ed25519
 )
 
 const (

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -27,7 +27,7 @@ const (
 	SignatureSize = ed25519.SignatureSize
 
 	// CurvePointSize defines the size of a curve point in bytes.
-	CurvePointSize = ed25519.SeedSize
+	CurvePointSize = ed25519.CurvePointSize
 )
 
 var (

--- a/crypto/signatures.go
+++ b/crypto/signatures.go
@@ -27,7 +27,7 @@ const (
 	SignatureSize = ed25519.SignatureSize
 
 	// CurvePointSize defines the size of a curve point in bytes.
-	CurvePointSize = ed25519.CurvePointSize
+	CurvePointSize = ed25519.SeedSize
 )
 
 var (

--- a/modules/miningpool/handler.go
+++ b/modules/miningpool/handler.go
@@ -246,8 +246,8 @@ func (h *Handler) handleStratumSubscribe(m *types.StratumRequest) error {
 	}
 
 	if len(m.Params) > 0 && m.Params[0].(string) == "sgminer/4.4.2" {
-		h.s.SetHighestDifficulty(4812.8)
-		h.s.SetCurrentDifficulty(4812.8)
+		h.s.SetHighestDifficulty(11500)
+		h.s.SetCurrentDifficulty(11500)
 		h.s.SetDisableVarDiff(true)
 	}
 	if len(m.Params) > 0 && m.Params[0].(string) == "cgminer/4.9.0" {


### PR DESCRIPTION
Errors in signatures.go causing hyperspace to not compile have been corrected in this update. Also fixed the proper hash rates for s11 miners.
