### PR TITLE
Update nodes.go

### DIFF
--- a/modules/gateway/nodes.go
+++ b/modules/gateway/nodes.go
@@ -20,7 +20,7 @@ var (
 	errPeerGenesisID = errors.New("peer has different genesis ID")
 )
 
-// A node represents a potential peer on the Sia network.
+// A node represents a potential peer on the Hyperspace network.
 type node struct {
 	NetAddress      modules.NetAddress `json:"netaddress"`
 	WasOutboundPeer bool               `json:"wasoutboundpeer"`


### PR DESCRIPTION
1.) Update the word Sia to Hyperspace in one of the comments. 
The comment line below was left alone because I am not aware of any changes that were made to the gateway handshake protocol after being forked: 
// staticPingNode verifies that there is a reachable node at the provided address
// by performing the Sia gateway handshake protocol.