### PR TITLE
Added support for dbSocket use by mining pool.

### DIFF
--- a/cmd/hsd/daemon.go
+++ b/cmd/hsd/daemon.go
@@ -170,6 +170,10 @@ func readFileConfig(config Config) error {
 		dbPort := poolViper.GetString("dbport")
 		dbName := poolViper.GetString("dbname")
 		dbConnection := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", dbUser, dbPass, dbAddress, dbPort, dbName)
+		dbSocket := poolViper.GetString("dbSocket")
+		if poolViper.IsSet("dbSocket") {
+	  	dbConnection = fmt.Sprintf("%s:%s@unix(%s)/%s", dbUser, dbPass, dbSocket, dbName)
+		} 
 		poolConfig := fileConfig.MiningPoolConfig{
 			PoolNetworkPort:  int(poolViper.GetInt("networkport")),
 			PoolName:         poolViper.GetString("name"),

--- a/modules/miningpool/worker.go
+++ b/modules/miningpool/worker.go
@@ -49,7 +49,11 @@ func newWorker(c *Client, name string, s *Session) (*Worker, error) {
 
 	// Initialize the logger, and set up the stop call that will close the
 	// logger.
-	w.log, err = p.dependencies.newLogger(filepath.Join(dirname, name+".log"))
+	namelen := len(name)
+	w.log, err = p.dependencies.newLogger(filepath.Join(dirname, "defaultworker.log"))
+	if namelen > 0 {
+		w.log, err = p.dependencies.newLogger(filepath.Join(dirname, name+".log"))
+	}
 
 	return w, err
 }


### PR DESCRIPTION
Allows the use of sockets vs tcp for mining pool database communication. Also resolved issue with log file naming for workers without usernames.