### PR TITLE
Release binaries for raspberry pi, simplifying process to setup a host

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -27,31 +27,41 @@ fi
 # setup build-time vars
 ldflags="-s -w -X 'github.com/HyperspaceApp/Hyperspace/build.GitRevision=`git rev-parse --short HEAD`' -X 'github.com/HyperspaceApp/Hyperspace/build.BuildTime=`date`'"
 
-for os in darwin linux windows; do
-	echo Packaging ${os}...
-	# create workspace
-	folder=release/Hyperspace-$version-$os-amd64
-	rm -rf $folder
-	mkdir -p $folder
-	# compile and sign binaries
-	for pkg in hsc hsd; do
-		bin=$pkg
-		if [ "$os" == "windows" ]; then
-			bin=${pkg}.exe
-		fi
-		GOOS=${os} go build -a -tags 'netgo' -ldflags="$ldflags" -o $folder/$bin ./cmd/$pkg
-		openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
-		# verify signature
-		if [[ -n $pubkeyfile ]]; then
-			openssl dgst -sha256 -verify $pubkeyfile -signature $folder/${bin}.sig $folder/$bin
+for arch in amd64 arm; do
+	for os in darwin linux windows; do
+
+		if [ "$arch" == "arm" ]; then
+			if [ "$os" == "windows" ] || [ "$os" == "darwin" ]; then
+				continue
+			fi
 		fi
 
+		echo Packaging ${os} ${arch}...
+		# create workspace
+		folder=release/Hyperspace-$version-$os-$arch
+		rm -rf $folder
+		mkdir -p $folder
+		# compile and sign binaries
+		for pkg in hsc hsd; do
+			bin=$pkg
+			if [ "$os" == "windows" ]; then
+				bin=${pkg}.exe
+			fi
+			GOOS=${os} GOARCH=${arch} go build -a -tags 'netgo' -ldflags="$ldflags" -o $folder/$bin ./cmd/$pkg
+			openssl dgst -sha256 -sign $keyfile -out $folder/${bin}.sig $folder/$bin
+			# verify signature
+			if [[ -n $pubkeyfile ]]; then
+				openssl dgst -sha256 -verify $pubkeyfile -signature $folder/${bin}.sig $folder/$bin
+			fi
+
+		done
+		# add other artifacts
+		cp -r doc LICENSE README.md $folder
+		# zip
+		(
+			cd release
+			zip -rq Hyperspace-$version-$os-$arch.zip Hyperspace-$version-$os-$arch
+		)
 	done
-	# add other artifacts
-	cp -r doc LICENSE README.md $folder
-	# zip
-	(
-		cd release
-		zip -rq Hyperspace-$version-$os-amd64.zip Hyperspace-$version-$os-amd64
-	)
 done
+


### PR DESCRIPTION
Simplify setup for new hosts and renters using the raspberry pi.

This guide can then be simplified to remove the golang build bits:
https://github.com/e-corp-sam-sepiol/spacenode/

This docker image can be reduced in size by about 400mb and built much faster as no need to build/compile via golang
https://hub.docker.com/r/afdy/hyperspace-pi/
